### PR TITLE
mall's shopsInfo&cross_street_name_destroy

### DIFF
--- a/app/assets/javascripts/locations.js
+++ b/app/assets/javascripts/locations.js
@@ -1,16 +1,24 @@
 $(document).ready(function(){
 	/*logoタッチ&shop詳細fadeIn*/
 	let step_info = $('li.hidei'),
-			mallInfo=$('.mallInfo');
+			mallInfo=$('.mallInfo'),
+			mallShopInfo=$('ul.mallShopInfo');
 			step_info.hide();
 			mallInfo.hide();
+			mallShopInfo.hide();
   $('.info_fadeout').bind('touchstart', function() {
-  	step_info.hide();
+  	//step_info.hide();
+  	$(this).parent('.hidei').hide();
   	return false;//消された状態をキープ
 	});
 	
 	$('ul.shops').bind('touchstart', function() {
 		$(this).children('li.hidei').fadeIn().offset({ top: 300, left: 120 });
+	});
+	
+	$('li.tenants').bind('touchstart', function() {
+		console.log("こっちだお");
+		$(this).next('ul.mallShopInfo').fadeIn();
 	});
 	//logoタッチ終わり//
 	

--- a/app/assets/stylesheets/_kawaii.scss
+++ b/app/assets/stylesheets/_kawaii.scss
@@ -19,7 +19,8 @@ $purple: #483d8b;
 
 //ハッキリ強調textShadow
 @mixin text_shadow{
-	text-shadow: 1px 1px 1px #ffffff, -1px -1px 2px #ffffff;
+	text_shadow: 10px 10px 10px #f9f3cd, -10px -10px 20px #f9f3cd;
+	
 }
 $kawaii_style: "#menu2";
 $chic_style: "#menu3";

--- a/app/assets/stylesheets/shops.scss
+++ b/app/assets/stylesheets/shops.scss
@@ -72,8 +72,8 @@
 	padding-top: 1vh;
 	//background-color: rgba(213, 164, 174, 0.61);
 	//border-radius: 4vh;
-	@include text_shadow;
-	//text-shadow: $text_shadow;
+	//@include text_shadow;
+	text-shadow: 10px 10px 15px #fdfcf1, -9px 10px 10px #fdfcf1, -6px -10px 10px #fdfcf1;
 }
 
 .shop_category{
@@ -150,7 +150,6 @@
 	width: 9vw;
 	font-size: 4rem;
 }
-
 	.shop_link{
 		//border: 1px dotted green;
 		position: absolute;
@@ -162,7 +161,13 @@
 		background-color: lighten($chic_accsentA, 5%);
 		border-radius: 1vh;
 	}
+ul.mallShopInfo{
+	position: absolute;
+	list-style: none;
+	left: -5vw;
+	top: 6vh;
 
+}
 /*.shop_campaign{Shopモデルでdevise入ったら復活？
 	//border: 1px dotted green;
 	position: absolute;
@@ -171,4 +176,3 @@
 	font-size: 2.1rem;
 	bottom: 5%;
 }*/
-

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -3,7 +3,10 @@ class ShopsController < ApplicationController
 	def show#render partialでは使わない
 	end
 	
-	def index
+	def index#お問い合わせ
+	end
+	
+	def mallShop#モール内店舗
 	end
 	
 end

--- a/app/views/locations/_cityscape0.html.erb
+++ b/app/views/locations/_cityscape0.html.erb
@@ -32,10 +32,8 @@
 							<% if @tenant.logo_url.blank? %>
 								<span class="shop_name"><%= @tenant.shop_name %></span>
 							<% end %>
-							<li class="hidei">
 
 								<%= render partial: 'shops/show', locals: { id: @tenant.id, locationId: num, each_bldg: each_bldg } %>
-							</li>
 						</ul>
 
 					<% elsif index >= 0 && ind >=1 then %><!--隣の2階以上￥-->
@@ -51,12 +49,13 @@
 									<% end %>
 
 								">
-							<% if @tenant.logo_url.blank? %>
-								<span class="shop_name"><%= @tenant.shop_name %></span>
-							<% end %>
-							<li class="hidei">
+									<% if @tenant.shop_name=="cross_street" %>
+										<span class="shop_name"><%= "" %></span>
+									<% elsif @tenant.logo_url.blank? %>
+										<span class="shop_name"><%= @tenant.shop_name %></span>
+									<% end %>
+
 								<%= render partial: "shops/show", locals: { id: @tenant.id, locationId: num, each_bldg: each_bldg  } %>
-							</li>
 						</ul>
 
 					<% elsif index >= 0 then %><!--隣の1階-->
@@ -78,12 +77,14 @@
 										<%= @crossingStreet %>
 									<% end %>
 									">
-							<% if @tenant.logo_url.blank? %>
-								<span class="shop_name"><%= @tenant.shop_name %></span>
-							<% end %>
-							<li class="hidei">
+
+										<% if @tenant.shop_name=="cross_street" %>
+											<span class="shop_name"><%= "" %></span>
+										<% elsif @tenant.logo_url.blank? %>
+											<span class="shop_name"><%= @tenant.shop_name %></span>
+										<% end %>
+
 								<%= render partial: "shops/show", locals: { id: @tenant.id, locationId: num, each_bldg: each_bldg } %>
-							</li>
 						</ul>
 						
 					<% elsif index == 0 then %><!--最初の建物1階-->
@@ -106,9 +107,8 @@
 							<% if @tenant.logo_url.blank? %>
 								<span class="shop_name"><%= @tenant.shop_name %></span>
 							<% end %>
-							<li class="hidei">
+
 									<%= render partial: "shops/show", locals: { id: @tenant.id, locationId: num, each_bldg: each_bldg } %>
-							</li>
 						</ul>
 						
 					<% end %><!--elsifいっぱいのend-->

--- a/app/views/locations/_cityscape1.html.erb
+++ b/app/views/locations/_cityscape1.html.erb
@@ -32,9 +32,8 @@
 								<% if @tenant.logo_url.blank? %>
 									<span class="shop_name"><%= @tenant.shop_name %></span>
 								<% end %>
-							<li class="hidei">
+
 								<%= render partial: 'shops/show', locals: { id: @tenant.id, locationId: num, each_bldg: each_bldg } %>
-							</li>
 						</ul>
 
 					<% elsif index >= 0 && ind >=1 then %><!--隣の2階以上￥-->
@@ -52,9 +51,8 @@
 							<% if @tenant.logo_url.blank? %>
 								<span class="shop_name"><%= @tenant.shop_name %></span>
 							<% end %>
-							<li class="hidei">
+
 								<%= render partial: "shops/show", locals: { id: @tenant.id, locationId: num, each_bldg: each_bldg  } %>
-							</li>
 						</ul>
 
 					<% elsif index >= 0 then %><!--隣の1階-->
@@ -76,13 +74,14 @@
 										<%= @crossingStreet %>
 									<% end %>
 									">
-								<% if @tenant.logo_url.blank? %>
-									<span class="shop_name"><%= @tenant.shop_name %></span>
-								<% end %>
-							<li class="hidei">
 
-								<%= render partial: "shops/show", locals: { id: @tenant.id, locationId: num, each_bldg: each_bldg } %>
-							</li>
+										<% if @tenant.shop_name=="cross_street" %>
+											<span class="shop_name"><%= "" %></span>
+										<% elsif @tenant.logo_url.blank? %>
+											<span class="shop_name"><%= @tenant.shop_name %></span>
+										<% end %>
+
+							<%= render partial: "shops/show", locals: { id: @tenant.id, locationId: num, each_bldg: each_bldg } %>
 						</ul>
 						
 					<% elsif index == 0 then %><!--最初の建物1階-->
@@ -102,13 +101,13 @@
 										<%= @crossingStreet %>
 									<% end %>
 								">
-								<% if @tenant.logo_url.blank? %>
-									<span class="shop_name"><%= @tenant.shop_name %></span>
-								<% end %>
-							<li class="hidei">
+									<% if @tenant.shop_name=="cross_street" %>
+										<span class="shop_name"><%= "" %></span>
+									<% elsif @tenant.logo_url.blank? %>
+										<span class="shop_name"><%= @tenant.shop_name %></span>
+									<% end %>
 
-									<%= render partial: "shops/show", locals: { id: @tenant.id, locationId: num, each_bldg: each_bldg } %>
-							</li>
+							<%= render partial: "shops/show", locals: { id: @tenant.id, locationId: num, each_bldg: each_bldg } %>
 						</ul>
 						
 					<% end %><!--elsifいっぱいのend-->

--- a/app/views/shops/_mallShop.html.erb
+++ b/app/views/shops/_mallShop.html.erb
@@ -1,0 +1,29 @@
+<% @id=id %>
+<% @shop=Shop.find(@id) %>
+<ul class="mallShopInfo">
+<li class="mallShop">
+
+<div class="hidei">
+	<div id="info_fadeout" class="info_fadeout">×</div>
+
+<div id="shop_name"><%= @shop.shop_name %></div>
+	<div id="shop_img_grid_contaier">
+		<div id="shop_img1" style="background-image:url(<%= asset_path 'shop_img1.jpg' %>)"></div>
+		<div id="shop_img2" style="background-image:url(<%= asset_path 'shop_img5.jpg' %>)"></div>
+		<div id="shop_img3" style="background-image:url(<%= asset_path 'shop_img3.jpg' %>)"></div>
+		<div id="shop_img4" style="background-image:url(<%= asset_path 'shop_img4.jpg' %>)"></div>
+		<div id="shop_img5" style="background-image:url(<%= asset_path 'shop_img2.jpg' %>)"></div>
+	</div><!--shop_img_grid_contaier-->
+
+<div class="shop_category">
+	<% @shop.category.to_s.split("-").each do |i| %>
+		<%= "##{i}" %>
+	<% end %>
+</div>
+			<!--<div class="shop_campaign">Campaign  >></div>-->
+
+<div class="shop_floor"><%= @shop.floor %>F</div>
+<div class="shop_link"><%= link_to'ShopWebSite',@shop.url %></div>
+
+</li>
+</ul>

--- a/app/views/shops/_show.html.erb
+++ b/app/views/shops/_show.html.erb
@@ -23,10 +23,13 @@
 						<%= @grayAction %>
 					<% end %>
 				">
+					
 					<% if tenant.logo_url.blank? %>
 						<span class="shop_nameMall"><%= tenant.shop_name %></span>
 					<% end %>
+					<!--モール店舗詳細-->
 				</li>
+					<%= render partial: 'shops/mallShop', locals: {id: tenant.id } %>
 			<% end %>
 			</ul>
 			</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 	root "locations#index"
 	get "locations/index"
-	resources :shops, only: [:show, :index]
+	resources :shops, only: [:show, :index, :mallShop]
 	resources :locations, only: [:index, :cityscape0, :cityscape1]
 end


### PR DESCRIPTION
Mall要素内のshopsに詳細ページを付けた。挙動はshops要素と同じ。
shop/show.html=>mall要素, cross_street要素, shops要素　この振り分けになった。
shop/mallShop.html.erb=>mall要素内のshop要素。

location/indexの"cross_street"表記を消す。span.shop_nameで分岐させた。 